### PR TITLE
GitPub improvement

### DIFF
--- a/.github/workflows/OnIssue.yml
+++ b/.github/workflows/OnIssue.yml
@@ -38,6 +38,10 @@ jobs:
                     "Repository": "GitPub",
                     "IssueState": "All"
                 },
+                "Get-GitPubRelease": {
+                    "UserName": "StartAutomating",
+                    "Repository": "GitPub"
+                },
                 "Publish-GitPubJekyll": {
                     "OutputPath": "docs/_posts"
                 }

--- a/.github/workflows/OnIssue.yml
+++ b/.github/workflows/OnIssue.yml
@@ -1,0 +1,26 @@
+
+on: 
+  issues: 
+jobs: 
+  RunGitPub: 
+    runs-on: ubuntu-latest
+    if: ${{ success() }}
+    steps: 
+      - name: Check out repository
+        uses: actions/checkout@v2
+      - name: Use GitPub Action
+        uses: StartAutomating/GitPub@main
+        id: GitPub
+        with: 
+          PublishParameters: |
+            {
+                "Get-GitPubIssue": {
+                    "UserName": "StartAutomating",
+                    "Repository": "GitPub",
+                    "IssueState": "All"
+                },
+                "Publish-GitPubJekyll": {
+                    "OutputPath": "docs/_posts"
+                }
+            }
+

--- a/.github/workflows/OnIssue.yml
+++ b/.github/workflows/OnIssue.yml
@@ -12,6 +12,7 @@ jobs:
         uses: StartAutomating/GitPub@main
         id: GitPub
         with: 
+          TargetBranch: edits-$([DateTime]::Now.ToString("o").Replace(":","-"))
           PublishParameters: |
             {
                 "Get-GitPubIssue": {

--- a/.github/workflows/OnIssue.yml
+++ b/.github/workflows/OnIssue.yml
@@ -18,6 +18,7 @@ on:
     - unlocked
     - milestoned
     - demilestoned
+  workflow_dispatch: 
 jobs: 
   RunGitPub: 
     runs-on: ubuntu-latest

--- a/.github/workflows/OnIssue.yml
+++ b/.github/workflows/OnIssue.yml
@@ -1,7 +1,24 @@
 
 on: 
   issues: 
-jobs:
+    types: 
+    - opened
+    - edited
+    - deleted
+    - transferred
+    - pinned
+    - unpinned
+    - closed
+    - reopened
+    - assigned
+    - unassigned
+    - labeled
+    - unlabeled
+    - locked
+    - unlocked
+    - milestoned
+    - demilestoned
+jobs: 
   RunGitPub: 
     runs-on: ubuntu-latest
     if: ${{ success() }}

--- a/.github/workflows/OnIssue.yml
+++ b/.github/workflows/OnIssue.yml
@@ -1,7 +1,7 @@
 
 on: 
   issues: 
-jobs: 
+jobs:
   RunGitPub: 
     runs-on: ubuntu-latest
     if: ${{ success() }}

--- a/.github/workflows/TestAndPublish.yml
+++ b/.github/workflows/TestAndPublish.yml
@@ -529,6 +529,7 @@ jobs:
         uses: StartAutomating/GitPub@main
         id: GitPub
         with: 
+          PublishParameters: 
       - name: BuildPipeScript
         uses: StartAutomating/PipeScript@main
       - name: UseEZOut

--- a/.github/workflows/TestAndPublish.yml
+++ b/.github/workflows/TestAndPublish.yml
@@ -525,14 +525,26 @@ jobs:
       - name: Use PSSVG Action
         uses: StartAutomating/PSSVG@main
         id: PSSVG
-      - name: Use GitPub Action
-        uses: StartAutomating/GitPub@main
-        id: GitPub
       - name: BuildPipeScript
         uses: StartAutomating/PipeScript@main
       - name: UseEZOut
         uses: StartAutomating/EZOut@master
       - name: UseHelpOut
         uses: StartAutomating/HelpOut@master
+      - name: Use GitPub Action
+        uses: StartAutomating/GitPub@main
+        id: GitPub
+        with: 
+          PublishParameters: |
+            {
+                "Get-GitPubIssue": {
+                    "UserName": "StartAutomating",
+                    "Repository": "GitPub",
+                    "IssueState": "All"
+                },
+                "Publish-GitPubJekyll": {
+                    "OutputPath": "docs/_posts"
+                }
+            }
 env: 
   NoCoverage: true

--- a/.github/workflows/TestAndPublish.yml
+++ b/.github/workflows/TestAndPublish.yml
@@ -542,6 +542,10 @@ jobs:
                     "Repository": "GitPub",
                     "IssueState": "All"
                 },
+                "Get-GitPubRelease": {
+                    "UserName": "StartAutomating",
+                    "Repository": "GitPub"
+                },
                 "Publish-GitPubJekyll": {
                     "OutputPath": "docs/_posts"
                 }

--- a/.github/workflows/TestAndPublish.yml
+++ b/.github/workflows/TestAndPublish.yml
@@ -528,18 +528,6 @@ jobs:
       - name: Use GitPub Action
         uses: StartAutomating/GitPub@main
         id: GitPub
-        with: 
-          PublishParameters: |
-            {
-                "Get-GitPubIssue": {
-                    "UserName": "StartAutomating",
-                    "Repository": "GitPub",
-                    "IssueState": "All"
-                },
-                "Publish-GitPubJekyll": {
-                    "OutputPath": "docs/_posts"
-                }
-            }
       - name: BuildPipeScript
         uses: StartAutomating/PipeScript@main
       - name: UseEZOut

--- a/.github/workflows/TestAndPublish.yml
+++ b/.github/workflows/TestAndPublish.yml
@@ -530,6 +530,12 @@ jobs:
         id: GitPub
         with: 
           PublishParameters: 
+            Get-GitPubIssue: 
+              UserName: StartAutomating
+              Repository: GitPub
+              IssueState: All
+            Publish-GitPubJekyll: 
+              OutputPath: docs/_posts
       - name: BuildPipeScript
         uses: StartAutomating/PipeScript@main
       - name: UseEZOut

--- a/.github/workflows/TestAndPublish.yml
+++ b/.github/workflows/TestAndPublish.yml
@@ -528,6 +528,7 @@ jobs:
       - name: Use GitPub Action
         uses: StartAutomating/GitPub@main
         id: GitPub
+        with: 
       - name: BuildPipeScript
         uses: StartAutomating/PipeScript@main
       - name: UseEZOut

--- a/.github/workflows/TestAndPublish.yml
+++ b/.github/workflows/TestAndPublish.yml
@@ -529,13 +529,17 @@ jobs:
         uses: StartAutomating/GitPub@main
         id: GitPub
         with: 
-          PublishParameters: 
-            Get-GitPubIssue: 
-              UserName: StartAutomating
-              Repository: GitPub
-              IssueState: All
-            Publish-GitPubJekyll: 
-              OutputPath: docs/_posts
+          PublishParameters: |
+            {
+                "Get-GitPubIssue": {
+                    "UserName": "StartAutomating",
+                    "Repository": "GitPub",
+                    "IssueState": "All"
+                },
+                "Publish-GitPubJekyll": {
+                    "OutputPath": "docs/_posts"
+                }
+            }
       - name: BuildPipeScript
         uses: StartAutomating/PipeScript@main
       - name: UseEZOut

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,16 @@
+## GitPub 0.1.1
+
+* Fixing GitHub Action Issues:
+  * TargetBranch was not pushing upstream (#21)
+  * Action Required Different Name from Repo (#22)
+* Publish-GitPub fixes:
+  * Publish parameters now correctly mapped (#20)
+* Publish-GitPubJekyll:
+  * Inlcuding .PostTitle in FrontMatter (#18)
+* Selfhosting Action (#19)
+
+---
+
 ## GitPub 0.1
 
 Introducing GitPub: Easily Automate Publishing from GitHub

--- a/GitHub/Actions/GitPubAction.ps1
+++ b/GitHub/Actions/GitPubAction.ps1
@@ -242,8 +242,15 @@ if ($CommitMessage -or $anyFilesChanged) {
     if (-not $LASTEXITCODE) {
         "::notice::Pulling Updates" | Out-Host
         git pull
-        "::notice::Pushing Changes" | Out-Host        
-        git push        
+        "::notice::Pushing Changes" | Out-Host
+        
+        $gitPushed = 
+            if ($TargetBranch) {
+                git push --set-upstream origin $TargetBranch
+            } else {
+                git push
+            }
+                
         "Git Push Output: $($gitPushed  | Out-String)"
     } else {
         "::notice::Not pushing changes (on detached head)" | Out-Host

--- a/GitPub.GitHubAction.PSDevOps.ps1
+++ b/GitPub.GitHubAction.PSDevOps.ps1
@@ -1,7 +1,7 @@
 ﻿#requires -Module PSDevOps
 #requires -Module GitPub
 Import-BuildStep -ModuleName GitPub
-New-GitHubAction -Name "gitpub" -Description 'Easily Automate Publishing from GitHub' -Action GitPubAction -Icon rss  -ActionOutput ([Ordered]@{
+New-GitHubAction -Name "usegitpub" -Description 'Easily Automate Publishing from GitHub' -Action GitPubAction -Icon rss  -ActionOutput ([Ordered]@{
     GitPubScriptRuntime = [Ordered]@{
         description = "The time it took the .GitPubScript parameter to run"
         value = '${{steps.GitPubAction.outputs.GitPubScriptRuntime}}'

--- a/GitPub.GitPub.ps1
+++ b/GitPub.GitPub.ps1
@@ -1,5 +1,7 @@
 #requires -Module GitPub
 
+return 
+
 Publish-GitPub -Parameter @{
     "Get-GitPubIssue" = @{
         "IssueState" = "All"

--- a/GitPub.psd1
+++ b/GitPub.psd1
@@ -1,5 +1,5 @@
 @{
-    ModuleVersion = '0.1'
+    ModuleVersion = '0.1.1'
     RootModule = 'GitPub.psm1'
     TypesToProcess = 'GitPub.types.ps1xml'
     FormatsToProcess = 'GitPub.format.ps1xml'
@@ -8,4 +8,22 @@
     Author='James Brundage'
     CompanyName='Start-Automating'
     Copyright='2022 Start-Automating'
+    PrivateData = @{
+        PSData = @{
+            ProjectURI = 'https://github.com/StartAutomating/GitPub'
+            LicenseURI = 'https://github.com/StartAutomating/GitPub/blob/main/LICENSE'
+            ReleaseNotes = @'
+## GitPub 0.1.1
+
+* Fixing GitHub Action Issues:
+  * TargetBranch was not pushing upstream (#21)
+  * Action Required Different Name from Repo (#22)
+* Publish-GitPub fixes:
+  * Publish parameters now correctly mapped (#20)
+* Publish-GitPubJekyll:
+  * Inlcuding .PostTitle in FrontMatter (#18)
+* Selfhosting Action (#19)
+'@
+        }
+    }
 }

--- a/Publish-GitPub.ps.ps1
+++ b/Publish-GitPub.ps.ps1
@@ -43,7 +43,7 @@ function Publish-GitPub
                         & $source @sourceParam
                     } catch {
                         $err = $_
-                        Write-Error "Could not run source '$source': $($err.Message)"                        
+                        Write-Error "Could not run source '$source': $($err.Message)"
                     }
                 }
             }
@@ -58,15 +58,14 @@ function Publish-GitPub
                     foreach ($prop in $publishParam.psobject.properties) {
                         $publishParamDict[$prop.Name] = $prop.Value
                     }
-                    $publishParam = $sourceParamDict
+                    $publishParam = $publishParamDict
                 }
                 $wasPublished = $true
                 try {
                     $gitPubSourceInfo | & $publisher @publishParam
                 } catch {
                     Write-Error "Could not run publisher '$publisher': $($err.Message)"
-                }
-                
+                }                
             }
         }
 

--- a/Publish-GitPub.ps.ps1
+++ b/Publish-GitPub.ps.ps1
@@ -18,6 +18,12 @@ function Publish-GitPub
     
     process {
         $gitPub = Get-GitPub
+
+        if ($env:GITHUB_WORKSPACE) {
+            "::group::Publish-GitPub Parameters" | Out-Host
+            $Parameter | Format-Custom | Out-Host
+            "::endgroup::" | Out-Host                        
+        }
         
         $gitPubSourceInfo = 
             foreach ($source in $gitPub.Sources) {

--- a/Publish-GitPub.ps.ps1
+++ b/Publish-GitPub.ps.ps1
@@ -39,7 +39,12 @@ function Publish-GitPub
                         $sourceParam = $sourceParamDict
                     }
                     
-                    & $source @sourceParam
+                    try {
+                        & $source @sourceParam
+                    } catch {
+                        $err = $_
+                        Write-Error "Could not run source '$source': $($err.Message)"                        
+                    }
                 }
             }
             
@@ -56,7 +61,12 @@ function Publish-GitPub
                     $publishParam = $sourceParamDict
                 }
                 $wasPublished = $true
-                $gitPubSourceInfo | & $publisher @publishParam
+                try {
+                    $gitPubSourceInfo | & $publisher @publishParam
+                } catch {
+                    Write-Error "Could not run publisher '$publisher': $($err.Message)"
+                }
+                
             }
         }
 

--- a/Publish-GitPub.ps1
+++ b/Publish-GitPub.ps1
@@ -17,6 +17,11 @@ function Publish-GitPub {
     
     process {
         $gitPub = Get-GitPub
+        if ($env:GITHUB_WORKSPACE) {
+            "::group::Publish-GitPub Parameters" | Out-Host
+            $Parameter | Format-Custom | Out-Host
+            "::endgroup::" | Out-Host                        
+        }
         
         $gitPubSourceInfo = 
             foreach ($source in $gitPub.Sources) {

--- a/Publish-GitPub.ps1
+++ b/Publish-GitPub.ps1
@@ -40,7 +40,7 @@ function Publish-GitPub {
                         & $source @sourceParam
                     } catch {
                         $err = $_
-                        Write-Error "Could not run source '$source': $($err.Message)"                        
+                        Write-Error "Could not run source '$source': $($err.Message)"
                     }
                 }
             }
@@ -55,15 +55,14 @@ function Publish-GitPub {
                     foreach ($prop in $publishParam.psobject.properties) {
                         $publishParamDict[$prop.Name] = $prop.Value
                     }
-                    $publishParam = $sourceParamDict
+                    $publishParam = $publishParamDict
                 }
                 $wasPublished = $true
                 try {
                     $gitPubSourceInfo | & $publisher @publishParam
                 } catch {
                     Write-Error "Could not run publisher '$publisher': $($err.Message)"
-                }
-                
+                }                
             }
         }
         if (-not $wasPublished) {

--- a/Publish-GitPubJekyll.ps.ps1
+++ b/Publish-GitPubJekyll.ps.ps1
@@ -72,7 +72,7 @@ function Publish-GitPubJekyll {
     }
 
     process {
-        $formattedDate = $PostCreationTime.ToString("yyyy-MM-dd")
+        $formattedDate = $PostCreationTime.ToLocalTime().ToString("yyyy-MM-dd")
         $safeTitle = $Posttitle -replace '[\p{P}-[\.]]' -replace '\s', '-'
         $postPath = Join-Path $OutputPath "$formattedDate-$safeTitle.md"
         $yamlHeader = $MarkdownYamlHeader.Matches($Postbody)

--- a/Publish-GitPubJekyll.ps.ps1
+++ b/Publish-GitPubJekyll.ps.ps1
@@ -78,7 +78,7 @@ function Publish-GitPubJekyll {
         $yamlHeader = $MarkdownYamlHeader.Matches($Postbody)
         $PostBody = $MarkdownYamlHeader.Replace($Postbody,'')
 
-        $frontMatter = [Ordered]@{PSTypeName='YamlHeader';Title= $PostTitle -replace '-', ' '}
+        $frontMatter = [Ordered]@{PSTypeName='YamlHeader';title= $PostTitle -replace '-', ' '}
         
         if ($PostLayout) {
             $frontMatter['layout'] = $PostLayout

--- a/Publish-GitPubJekyll.ps.ps1
+++ b/Publish-GitPubJekyll.ps.ps1
@@ -78,10 +78,12 @@ function Publish-GitPubJekyll {
         $yamlHeader = $MarkdownYamlHeader.Matches($Postbody)
         $PostBody = $MarkdownYamlHeader.Replace($Postbody,'')
 
-        $frontMatter = [Ordered]@{PSTypeName='YamlHeader'}
+        $frontMatter = [Ordered]@{PSTypeName='YamlHeader';Title= $PostTitle -replace '-', ' '}
+        
         if ($PostLayout) {
             $frontMatter['layout'] = $PostLayout
         }
+
 
         if ($PostAuthor) {
             $frontMatter['author'] = $PostAuthor

--- a/Publish-GitPubJekyll.ps1
+++ b/Publish-GitPubJekyll.ps1
@@ -65,7 +65,7 @@ function Publish-GitPubJekyll {
         $postPath = Join-Path $OutputPath "$formattedDate-$safeTitle.md"
         $yamlHeader = $MarkdownYamlHeader.Matches($Postbody)
         $PostBody = $MarkdownYamlHeader.Replace($Postbody,'')
-        $frontMatter = [Ordered]@{PSTypeName='YamlHeader';Title= $PostTitle -replace '-', ' '}
+        $frontMatter = [Ordered]@{PSTypeName='YamlHeader';title= $PostTitle -replace '-', ' '}
         
         if ($PostLayout) {
             $frontMatter['layout'] = $PostLayout

--- a/Publish-GitPubJekyll.ps1
+++ b/Publish-GitPubJekyll.ps1
@@ -65,7 +65,8 @@ function Publish-GitPubJekyll {
         $postPath = Join-Path $OutputPath "$formattedDate-$safeTitle.md"
         $yamlHeader = $MarkdownYamlHeader.Matches($Postbody)
         $PostBody = $MarkdownYamlHeader.Replace($Postbody,'')
-        $frontMatter = [Ordered]@{PSTypeName='YamlHeader'}
+        $frontMatter = [Ordered]@{PSTypeName='YamlHeader';Title= $PostTitle -replace '-', ' '}
+        
         if ($PostLayout) {
             $frontMatter['layout'] = $PostLayout
         }

--- a/Publish-GitPubJekyll.ps1
+++ b/Publish-GitPubJekyll.ps1
@@ -60,7 +60,7 @@ function Publish-GitPubJekyll {
 '@, 'Multiline,IgnorePatternWhitespace')
     }
     process {
-        $formattedDate = $PostCreationTime.ToString("yyyy-MM-dd")
+        $formattedDate = $PostCreationTime.ToLocalTime().ToString("yyyy-MM-dd")
         $safeTitle = $Posttitle -replace '[\p{P}-[\.]]' -replace '\s', '-'
         $postPath = Join-Path $OutputPath "$formattedDate-$safeTitle.md"
         $yamlHeader = $MarkdownYamlHeader.Matches($Postbody)

--- a/action.yml
+++ b/action.yml
@@ -1,5 +1,5 @@
 
-name: gitpub
+name: usegitpub
 description: Easily Automate Publishing from GitHub
 inputs: 
   GitPubScript: 

--- a/action.yml
+++ b/action.yml
@@ -320,8 +320,15 @@ runs:
             if (-not $LASTEXITCODE) {
                 "::notice::Pulling Updates" | Out-Host
                 git pull
-                "::notice::Pushing Changes" | Out-Host        
-                git push        
+                "::notice::Pushing Changes" | Out-Host
+                
+                $gitPushed = 
+                    if ($TargetBranch) {
+                        git push --set-upstream origin $TargetBranch
+                    } else {
+                        git push
+                    }
+                        
                 "Git Push Output: $($gitPushed  | Out-String)"
             } else {
                 "::notice::Not pushing changes (on detached head)" | Out-Host

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -1,3 +1,16 @@
+## GitPub 0.1.1
+
+* Fixing GitHub Action Issues:
+  * TargetBranch was not pushing upstream (#21)
+  * Action Required Different Name from Repo (#22)
+* Publish-GitPub fixes:
+  * Publish parameters now correctly mapped (#20)
+* Publish-GitPubJekyll:
+  * Inlcuding .PostTitle in FrontMatter (#18)
+* Selfhosting Action (#19)
+
+---
+
 ## GitPub 0.1
 
 Introducing GitPub: Easily Automate Publishing from GitHub

--- a/docs/README.md
+++ b/docs/README.md
@@ -67,3 +67,4 @@ Any function that adds `[Reflection.AssemblyMetadata('GitPub.Publisher','true')]
 
 
 
+

--- a/docs/README.md
+++ b/docs/README.md
@@ -67,4 +67,3 @@ Any function that adds `[Reflection.AssemblyMetadata('GitPub.Publisher','true')]
 
 
 
-

--- a/docs/_posts/2022-10-10-GitPub-0.1.md
+++ b/docs/_posts/2022-10-10-GitPub-0.1.md
@@ -7,7 +7,7 @@ tag: release
 
 Introducing GitPub: Easily Automate Publishing from GitHub
 
-See [https://gitpub.start-automating.com/2022/10/09/Introducing-GitPub.html](the first post)
+See [https://gitpub.start-automating.com/2022/10/10/Introducing-GitPub.html](the first post)
 
 
 GitPub provides a flexible way to publish content in a GitHub workflow.

--- a/docs/_posts/2022-10-10-GitPub-0.1.md
+++ b/docs/_posts/2022-10-10-GitPub-0.1.md
@@ -1,0 +1,38 @@
+---
+
+title: GitPub 0.1
+tag: release
+---
+## GitPub 0.1
+
+Introducing GitPub: Easily Automate Publishing from GitHub
+
+See [https://gitpub.start-automating.com/2022/10/09/Introducing-GitPub.html](the first post)
+
+
+GitPub provides a flexible way to publish content in a GitHub workflow.
+
+GitPub can be extended with Sources and Publishers.
+
+### GitPub Sources
+
+A source is a function that provides content to post.  GitPub comes with three sources:
+
+|Source|Function|Description|
+|-|-|-|
+|Gist       | Get-GitPubGist         | Turns gists into posts      |
+|Issue     | Get-GitPubIssue       | Turns issues into posts    |
+|Release | Get-GitPubRelease   | Turns releases into posts |
+
+~~~PowerShell
+Get-GitPub |
+    Select-Object -ExpandProperty Sources
+~~~
+
+### GitPub Publishers
+
+A publisher is a function that finalizes content and publishes it.  GitPub comes with one publisher:
+
+|Source|Function|Description|
+|-|-|-|
+|Jeykll    | Publish-GitPubJeykll | Publishes content to _posts directories    |

--- a/docs/_posts/2022-10-10-Introducing-GitPub.md
+++ b/docs/_posts/2022-10-10-Introducing-GitPub.md
@@ -1,5 +1,6 @@
 ---
 
+Title: Introducing GitPub
 author: StartAutomating
 tag: enhancement
 ---

--- a/docs/_posts/2022-10-10-Introducing-GitPub.md
+++ b/docs/_posts/2022-10-10-Introducing-GitPub.md
@@ -1,6 +1,6 @@
 ---
 
-Title: Introducing GitPub
+title: Introducing GitPub
 author: StartAutomating
 tag: enhancement
 ---

--- a/docs/_posts/2022-10-10-Introducing-GitPub.md
+++ b/docs/_posts/2022-10-10-Introducing-GitPub.md
@@ -6,7 +6,7 @@ tag: enhancement
 ---
 # Introducing GitPub
 
-GitPub is a GitHub Action and PowerShell Module that helps Easily Automate Publishing from GitHub.
+[GitPub](https://gitpub.start-automating.com/) is a GitHub Action and PowerShell Module that helps Easily Automate Publishing from GitHub.
 
 ## What does GitPub do?
 


### PR DESCRIPTION
## GitPub 0.1.1

* Fixing GitHub Action Issues:
  * TargetBranch was not pushing upstream (#21)
  * Action Required Different Name from Repo (#22)
* Publish-GitPub fixes:
  * Publish parameters now correctly mapped (#20)
* Publish-GitPubJekyll:
  * Inlcuding .PostTitle in FrontMatter (#18)
* Selfhosting Action (#19)